### PR TITLE
Fix to minimum deployment version for ios

### DIFF
--- a/ExampleTSProject/ios/Podfile
+++ b/ExampleTSProject/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 target 'ExampleTSProject' do
   config = use_native_modules!


### PR DESCRIPTION
With the newer version of RN, when trying to run a Pod Install fails due to the deployment level being too low for dependencies.

Upgrading minimum deployment level to 11.0 fixes this issue and allows pod-install to work as expected.